### PR TITLE
Feat/handle new post event

### DIFF
--- a/NotificationService/Configuration/SendingSettings.cs
+++ b/NotificationService/Configuration/SendingSettings.cs
@@ -1,0 +1,9 @@
+namespace NotificationService.Configuration;
+
+public class SendingSettings
+{
+    public string SiteUrl { get; set; } = string.Empty;
+
+    public bool IsValid() => !string.IsNullOrWhiteSpace(SiteUrl);
+}
+

--- a/NotificationService/Constants.cs
+++ b/NotificationService/Constants.cs
@@ -4,4 +4,5 @@ internal static class Constants
 {
     public const string ConfigFileName = "appsettings.json";
     public const string PostgresConnectionString = "PgConnection";
+    public const string BotTokenConnectionString = "BotToken";
 }

--- a/NotificationService/DataAccess/DtoExtensions.cs
+++ b/NotificationService/DataAccess/DtoExtensions.cs
@@ -12,4 +12,13 @@ internal static class DtoExtensions
             TelegramId = subscriber.TelegramId,
             LastUpdated = DateTime.UtcNow,
         };
+
+    public static Subscriber IntoDomain(this SubscriberDto subscriberDto)
+        => new()
+        {
+            Id = subscriberDto.Id,
+            BlogUserId = subscriberDto.BlogUserId,
+            TelegramId = subscriberDto.TelegramId,
+            SendNotification = subscriberDto.SendNotification,
+        };
 }

--- a/NotificationService/DependencyInjectionExtensions.cs
+++ b/NotificationService/DependencyInjectionExtensions.cs
@@ -1,6 +1,8 @@
 using MassTransit;
 using NotificationService.DataAccess;
 using NotificationService.Interfaces;
+using NotificationService.Interfaces.Bot;
+using NotificationService.TelegramBot;
 
 namespace NotificationService;
 
@@ -53,7 +55,9 @@ internal static class DependencyInjectionExtensions
     }
 
     internal static IServiceCollection AddDomain(this IServiceCollection services)
-        => services.AddTransient<ISubscribersDao, SubscribersDao>();
+        => services
+            .AddTransient<ISubscribersDao, SubscribersDao>()
+            .AddSingleton<IBotClient, TelegramBotClient>();
 
 }
 

--- a/NotificationService/Domain/BlogMessage.cs
+++ b/NotificationService/Domain/BlogMessage.cs
@@ -1,0 +1,7 @@
+namespace NotificationService.Domain;
+
+public static class BlogMessage
+{
+    public static string GetNewPostMessage(string blogUrl, string subLink)
+        => $"Новая публикация {Environment.NewLine} {blogUrl}/{subLink}";
+}

--- a/NotificationService/Events/NewPostPublished.cs
+++ b/NotificationService/Events/NewPostPublished.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace NotificationService.Events;
+
+internal sealed class NewPostPublished
+{
+    [JsonPropertyName("blog_user_id")]
+    public long BlogUserId { get; set; }
+
+    [JsonPropertyName("post_sub_url")]
+    public string PostSubUrl { get; set; } = string.Empty;
+}

--- a/NotificationService/Interfaces/Bot/IBotClient.cs
+++ b/NotificationService/Interfaces/Bot/IBotClient.cs
@@ -1,0 +1,9 @@
+namespace NotificationService.Interfaces.Bot;
+
+public interface IBotClient
+{
+    Task<bool> SendNotifications(
+        IEnumerable<long> userIds,
+        string message,
+        CancellationToken cancellation);
+}

--- a/NotificationService/Interfaces/DataAccess/ISubscribersDao.cs
+++ b/NotificationService/Interfaces/DataAccess/ISubscribersDao.cs
@@ -5,4 +5,6 @@ namespace NotificationService.Interfaces;
 public interface ISubscribersDao
 {
     Task Save(Subscriber subscriber, CancellationToken cancellation);
+
+    Task<IReadOnlyCollection<Subscriber>> GetActiveSubscribers(CancellationToken cancellation);
 }

--- a/NotificationService/Interfaces/IConsumeMessageByHeader.cs
+++ b/NotificationService/Interfaces/IConsumeMessageByHeader.cs
@@ -1,0 +1,7 @@
+namespace NotificationService.Interfaces;
+
+public interface IConsumeMessageByHeader
+{
+    string HeaderKey => "blog.events.type";
+    string HeaderValue { get; }
+}

--- a/NotificationService/NotificationService.csproj
+++ b/NotificationService/NotificationService.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageReference Include="Telegram.Bot" Version="19.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/NotificationService/PostConsumer.cs
+++ b/NotificationService/PostConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using NotificationService.Configuration;
+using NotificationService.Domain;
+using NotificationService.Events;
+using NotificationService.Interfaces;
+using NotificationService.Interfaces.Bot;
+
+namespace NotificationService;
+
+internal class PostConsumer(
+    ISubscribersDao subscribersDao,
+    IBotClient botClient,
+    SendingSettings settings,
+    ILogger<NotificationServiceWorker> logger)
+    : IConsumer<NewPostPublished>, IConsumeMessageByHeader
+{
+    public string HeaderValue => "newpostpublished";
+
+    public async Task Consume(ConsumeContext<NewPostPublished> context)
+    {
+        var postPublished = context.Message;
+
+        var usersToNotify = await subscribersDao.GetActiveSubscribers(CancellationToken.None);
+
+        await botClient.SendNotifications(
+            usersToNotify.Select(x => x.TelegramId).ToList(),
+            BlogMessage.GetNewPostMessage(settings.SiteUrl, postPublished.PostSubUrl),
+            CancellationToken.None);
+
+        logger.LogInformation("Event consumed. Post with suburl {}", postPublished.PostSubUrl);
+    }
+}

--- a/NotificationService/Program.cs
+++ b/NotificationService/Program.cs
@@ -11,13 +11,24 @@ var builder = Host.CreateDefaultBuilder(args)
     })
     .ConfigureServices((context, services) =>
     {
+        //rly??!!?
         NotificationServiceSettings getSettings(HostBuilderContext ctx) =>
             context.Configuration.GetSection(nameof(NotificationServiceSettings)).Get<NotificationServiceSettings>()
             ?? new();
+        var sendingSettings = context.Configuration
+            .GetSection(nameof(SendingSettings))
+            .Get<SendingSettings>() ?? new();
+
+        if (!sendingSettings.IsValid())
+        {
+            throw new ArgumentException("Send settings should be set"); // do not throw
+        }
 
         //TODO remove and register as transient when required
         var notificationSettings = getSettings(context);
         services.AddSingleton(notificationSettings);
+        services.AddSingleton(sendingSettings);
+
         services.AddHostedService<NotificationServiceWorker>();
 
         services.AddDomain();

--- a/NotificationService/SubscriptionConsumer.cs
+++ b/NotificationService/SubscriptionConsumer.cs
@@ -5,8 +5,12 @@ using NotificationService.Interfaces;
 
 namespace NotificationService;
 
-internal class SubscriptionConsumer(ISubscribersDao subscribersDao, ILogger<NotificationServiceWorker> logger) : IConsumer<SubscriptionStateChanged>
+internal class SubscriptionConsumer(ISubscribersDao subscribersDao, ILogger<NotificationServiceWorker> logger)
+    : IConsumer<SubscriptionStateChanged>,
+    IConsumeMessageByHeader
 {
+    public string HeaderValue => "subscriptionstatechanged";
+
     public async Task Consume(ConsumeContext<SubscriptionStateChanged> context)
     {
         var stateChanged = context.Message;

--- a/NotificationService/TelegramBot/TelegramBotClient.cs
+++ b/NotificationService/TelegramBot/TelegramBotClient.cs
@@ -1,18 +1,43 @@
 using NotificationService.Interfaces.Bot;
+using Telegram.Bot;
+using Telegram.Bot.Types;
 
 namespace NotificationService.TelegramBot;
 
-internal class TelegramBotClient(IConfiguration configuration) : IBotClient
+internal class TelegramBotClient : IBotClient
 {
-    private readonly string botToken = configuration.GetConnectionString(Constants.BotTokenConnectionString) ?? string.Empty;
+    private readonly Telegram.Bot.TelegramBotClient botClient;
+
+    //TODO do not send if telegram init failed
+    public TelegramBotClient(IConfiguration configuration)
+    {
+        var botToken = configuration.GetConnectionString(Constants.BotTokenConnectionString) ?? string.Empty;
+        botClient = new Telegram.Bot.TelegramBotClient(botToken);
+    }
 
     public async Task<bool> SendNotifications(IEnumerable<long> userIds, string message, CancellationToken cancellation)
     {
+        if (!userIds.Any())
+            return false;
+
         foreach (var userId in userIds)
         {
-            Console.WriteLine($"NOTIFICATION SENT {userId}- {message}");
+            var chat = await GetTelegramChatByUserId(userId);
+
+            if (chat is null)
+            {
+                Console.WriteLine("Could not find chat by userID");
+                continue;
+            }
+
+            await botClient.SendTextMessageAsync(chat.Id, message, cancellationToken: cancellation);
         }
+
+        Console.WriteLine($"NOTIFICATIONs SENT - {message}");
 
         return true;
     }
+
+    private async Task<Chat?> GetTelegramChatByUserId(long telegramUserId)
+        => await botClient.GetChatAsync(telegramUserId);
 }

--- a/NotificationService/TelegramBot/TelegramBotClient.cs
+++ b/NotificationService/TelegramBot/TelegramBotClient.cs
@@ -1,0 +1,18 @@
+using NotificationService.Interfaces.Bot;
+
+namespace NotificationService.TelegramBot;
+
+internal class TelegramBotClient(IConfiguration configuration) : IBotClient
+{
+    private readonly string botToken = configuration.GetConnectionString(Constants.BotTokenConnectionString) ?? string.Empty;
+
+    public async Task<bool> SendNotifications(IEnumerable<long> userIds, string message, CancellationToken cancellation)
+    {
+        foreach (var userId in userIds)
+        {
+            Console.WriteLine($"NOTIFICATION SENT {userId}- {message}");
+        }
+
+        return true;
+    }
+}

--- a/NotificationService/appsettings.json
+++ b/NotificationService/appsettings.json
@@ -6,10 +6,14 @@
     }
   },
   "ConnectionStrings": {
-    "PgConnection": ""
+    "PgConnection": "",
+    "BotToken": ""
   },
   "NotificationServiceSettings": {
     "MtRabbitMqConnectionString": "",
     "QueueName": ""
+  },
+  "SendingSettings": {
+    "SiteUrl": ""
   }
 }


### PR DESCRIPTION
MassTranit has its own conventions of message serialization/deserialization, thats wy we are using raw json deserializer. Also previous decisions for using one queue for all events led to problems with determining which message we should process and which not in multiple consumers scenario.

At sending side for each event added headers. Now we filtering all events by this header value.

Also added new post event handling with mpv telegram notification.